### PR TITLE
Fix wrong condition in NamePart

### DIFF
--- a/src/style/bst/names.jl
+++ b/src/style/bst/names.jl
@@ -13,7 +13,7 @@ function NamePart(format_list)
 	local tie = ""
 	local format_char = ""
 	local abbreviate = false
-	if length(format_chars)>0 && length(pre_text)>0 && length(post_text)<=0
+	if length(format_chars)<=0 && length(pre_text)>0 && length(post_text)<=0
 		post_text = pre_text
 		pre_text = ""
 	end


### PR DESCRIPTION
The original condition in the Python [source](https://bitbucket.org/pybtex-devs/pybtex/src/4c6cba725c9edb55f7801d1550a0dcb95bec480f/pybtex/bibtex/names.py?at=master&fileviewer=file-view-default#names.py-80) uses `if not format_chars`. This fix restores the correct behavior for, e.g., `NameFormat("{, jj}")`.