### PR TITLE
Update for Julia 0.7

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,123 @@
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BibTeX]]
+git-tree-sha1 = "c6a46a063b7ca3f69190270be6be07a5177509ab"
+repo-rev = "master"
+repo-url = "https://github.com/mpastell/BibTeX.jl.git"
+uuid = "0c132655-f423-5f6f-9a5a-d55cfa15b9d7"
+version = "0.0.0"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "49269e311ffe11ac5b334681d212329002a9832a"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "1.5.1"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[Format]]
+deps = ["Compat"]
+git-tree-sha1 = "89b70d12b4a01d4242ffd4351e8c8a571877e0eb"
+uuid = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
+version = "0.7.2"
+
+[[HttpCommon]]
+deps = ["Dates", "Nullables", "Test", "URIParser"]
+git-tree-sha1 = "46313284237aa6ca67a6bce6d6fbd323d19cff59"
+uuid = "77172c1b-203f-54ac-aa54-3f1198fe9f90"
+version = "0.5.0"
+
+[[InteractiveUtils]]
+deps = ["LinearAlgebra", "Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Nullables]]
+deps = ["Compat"]
+git-tree-sha1 = "ae1a63457e14554df2159b0b028f48536125092d"
+uuid = "4d1e1d77-625e-5b40-9113-a560ec7a8ecd"
+version = "0.0.8"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[URIParser]]
+deps = ["Test", "Unicode"]
+git-tree-sha1 = "6ddf8244220dfda2f17539fa8c9de20d6c575b69"
+uuid = "30578b45-9adc-5946-b283-645ec420af67"
+version = "0.4.0"
+
+[[UUIDs]]
+deps = ["Random"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -26,11 +26,11 @@ uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
-[[Format]]
+[[Formatting]]
 deps = ["Compat"]
-git-tree-sha1 = "89b70d12b4a01d4242ffd4351e8c8a571877e0eb"
-uuid = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
-version = "0.7.2"
+git-tree-sha1 = "289003271ce9c8194c1ce56a3c433f1c51841125"
+uuid = "59287772-0a20-5a39-b81b-1366585eb4c0"
+version = "0.3.5"
 
 [[HttpCommon]]
 deps = ["Dates", "Nullables", "Test", "URIParser"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "BibTexFormat"
+name = "BibTeXFormat"
 uuid = "81872a04-5f92-5ce1-a30b-528d3f2b00a0"
 version = "0.0.0"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,8 @@
+name = "BibTexFormat"
+uuid = "81872a04-5f92-5ce1-a30b-528d3f2b00a0"
+version = "0.0.0"
+
+[deps]
+BibTeX = "0c132655-f423-5f6f-9a5a-d55cfa15b9d7"
+Format = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
+HttpCommon = "77172c1b-203f-54ac-aa54-3f1198fe9f90"

--- a/Project.toml
+++ b/Project.toml
@@ -4,5 +4,6 @@ version = "0.0.0"
 
 [deps]
 BibTeX = "0c132655-f423-5f6f-9a5a-d55cfa15b9d7"
-Format = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
+Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
 HttpCommon = "77172c1b-203f-54ac-aa54-3f1198fe9f90"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
-julia 0.6
+julia 0.7
 BibTeX
 HttpCommon
 Formatting
-Iterators

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,1 +1,1 @@
-Pkg.clone("https://github.com/bramtayl/BibTeX.jl.git")
+#Pkg.clone("https://github.com/bramtayl/BibTeX.jl.git")

--- a/src/BibTeXFormat.jl
+++ b/src/BibTeXFormat.jl
@@ -1,8 +1,8 @@
 module BibTeXFormat
 
-export BaseStyle,
-       format_entries
+export BaseStyle, format_entries
 using BibTeX
+
 
 function render_as() end
 include("utils.jl")

--- a/src/backends/backends.jl
+++ b/src/backends/backends.jl
@@ -174,7 +174,7 @@ function find_backend(t::String)
     end
 end
 
-doc"""
+"""
 ```
 function render_as(self::T, backend_name) where T<:BaseText
 ```
@@ -197,7 +197,6 @@ Longcat is looooooong!
 ```
 
 """
-
 function render_as(self::T, backend_name) where T<:BaseText
 	backend_cls = find_backend(backend_name)
 	return render(self,backend_cls())

--- a/src/backends/html.jl
+++ b/src/backends/html.jl
@@ -10,7 +10,7 @@ const PROLOGUE = """<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">
 <dl>
 """
 
-doc"""
+"""
 ```
 struct HTMLBackend <: BaseBackend
 ```

--- a/src/backends/latex.jl
+++ b/src/backends/latex.jl
@@ -1,6 +1,6 @@
-using Base.Test
+using Test
 
-doc"""
+"""
 LaTeX output backend.
 ```jldoctest
 julia> import BibTeXFormat: LaTeXBackend, render
@@ -12,13 +12,13 @@ julia> latex = LaTeXBackend();
 julia> print(render(Tag("em", ""),latex))
 
 julia> print(render(Tag("em", "Non-", "empty"),latex))
-\emph{Non-empty}
+\\emph{Non-empty}
 julia> print(render(HRef("/", ""),latex))
 
 julia> print(render(HRef("/", "Non-", "empty"),latex))
-\href{/}{Non-empty}
+\\href{/}{Non-empty}
 julia> print(render(HRef("http://example.org/", "http://example.org/"),latex))
-\url{http://example.org/}
+\\url{http://example.org/}
 ```
 """
 struct LaTeXBackend <: BaseBackend

--- a/src/latexparser.jl
+++ b/src/latexparser.jl
@@ -20,7 +20,7 @@ end
 
 function iter_string_parts(str)
 	parts = Any[RichText("")]
-	tokens  = matchall(r"[^\s\"#{}@,=\\]+|\s+|\"|#|{|}|@|,|=|\\", str)
+	tokens  = matchall(r"[^\s\"#{}@,=\\]+|\s+|\"|#|{|}|@|,|=|\\\\", str)
 	i = 1
 	e = 1
 	bb = []

--- a/src/person.jl
+++ b/src/person.jl
@@ -197,28 +197,28 @@ function _parse_string(self::Person, name::String)
     end
 
     function is_von_name(string)
-        if isupper(string[1])
+        if isuppercase(string[1])
             return false
         end
-        if islower(string[1])
+        if islowercase(string[1])
             return true
         else
             for (char, brace_level) in scan_bibtex_string(string)
                 if brace_level == 0 && isalpha(char)
-                    return islower(char)
+                    return islowercase(char)
                 elseif brace_level == 1
                     if (isa(char,Char) && char == '\\' ) || ((isa(char, String)) &&  startswith(char,'\\'))
-                        return special_char_islower(char)
+                        return special_char_islowercase(char)
                     end
                 end
             end
         end
         return false
     end
-    function special_char_islower(special_char::Char)
-        return islower(special_char)
+    function special_char_islowercase(special_char::Char)
+        return islowercase(special_char)
     end
-    function special_char_islower(special_char::String)
+    function special_char_islowercase(special_char::String)
         control_sequence = true
         for char in special_char[2:end]  # skip the backslash
             if control_sequence
@@ -227,7 +227,7 @@ function _parse_string(self::Person, name::String)
                 end
             else
                 if isalpha(char)
-                    return islower(char)
+                    return islowercase(char)
                 end
             end
         end

--- a/src/richtextelements.jl
+++ b/src/richtextelements.jl
@@ -22,7 +22,7 @@ import BibTeXFormat: whitespace_re, render_as
 function typeinfo(v::T) where T<:BaseText
     return (string(T),T,())
 end
-using Iterators
+#using Iterators
 function ensure_text(c::Char)
     return RichString(string(c))
 end
@@ -201,7 +201,7 @@ end
 function parts(d::T) where T<:MultiPartText
     return d.parts
 end
-function show(io::Union{IO,Base.AbstractIOBuffer}, d::T) where {T<:MultiPartText}
+function show(io::Union{IO,Base.GenericIOBuffer}, d::T) where {T<:MultiPartText}
     write(io,string(T.name.name))
     write(io,"(")
     write(io,Base.join([string(part) for part in d.parts], ", "))
@@ -623,7 +623,7 @@ end
 function Base.endof(v::RichString)
     return length(v.value)
 end
-function Base.show(io::Union{IO,Base.AbstractIOBuffer}, self::RichString)
+function Base.show(io::Union{IO,Base.GenericIOBuffer}, self::RichString)
     write(io, "\"")
     write(io, self.value)
     write(io,"\"")
@@ -723,17 +723,17 @@ function unpack(r::RichText)
 	end
 	return elems
 end
-function write(io::Base.AbstractIOBuffer, d::RichText)
+function write(io::Base.GenericIOBuffer, d::RichText)
     show(io,d)
 end
 
-function show(io::Union{IO,Base.AbstractIOBuffer}, d::RichText)
+function show(io::Union{IO,Base.GenericIOBuffer}, d::RichText)
     write(io,"RichText")
     write(io,"(")
     write(io,Base.join([string(part) for part in d.parts], ", "))
     write(io,")")
 end
-doc"""
+"""
 A `Tag` represents something like an HTML tag or a LaTeX formatting command:
 
 ```jldoctest
@@ -760,7 +760,7 @@ mutable struct Tag <:MultiPartText
 	end
 end
 
-function Base.show(io::Union{IO, Base.AbstractIOBuffer}, self::Tag)
+function Base.show(io::Union{IO, Base.GenericIOBuffer}, self::Tag)
     write(io,"Tag")
     write(io,"(\"")
     write(io, self.name)
@@ -769,7 +769,7 @@ function Base.show(io::Union{IO, Base.AbstractIOBuffer}, self::Tag)
     write(io,")")
 end
 
-doc"""
+"""
 A `HRef` represends a hyperlink:
 ```jldoctest
 julia> import BibTeXFormat: render_as
@@ -780,12 +780,12 @@ julia> print(render_as(href,"html"))
 <a href="http://ctan.org/">CTAN</a>
 
 julia> print(render_as(href, "latex"))
-\href{http://ctan.org/}{CTAN}
+\\href{http://ctan.org/}{CTAN}
 
 julia> href = HRef(String("http://ctan.org/"), String("http://ctan.org/"));
 
 julia> print(render_as(href,"latex"))
-\url{http://ctan.org/}
+\\url{http://ctan.org/}
 
 ```
 
@@ -801,7 +801,7 @@ mutable struct HRef <: MultiPartText
     end
 end
 
-function Base.show(io::Union{IO, Base.AbstractIOBuffer}, self::HRef)
+function Base.show(io::Union{IO, Base.GenericIOBuffer}, self::HRef)
     write(io,"HRef")
     write(io,"(\"")
     write(io, self.url)
@@ -810,7 +810,7 @@ function Base.show(io::Union{IO, Base.AbstractIOBuffer}, self::HRef)
     write(io,")")
 end
 
-doc"""
+"""
 A `Protected` represents a "protected" piece of text.
 
 - `Protected.lowercase`, `Protected.uppercase`, `Protected.capitalize`, and `Protected.capitalize()`   are no-ops and just return the `Protected` struct itself.

--- a/src/style/bst/bst.jl
+++ b/src/style/bst/bst.jl
@@ -20,7 +20,7 @@ type Style <: BaseStyle
 ```
 A Style obtained from a .bst file
 """
-type Style <: BaseStyle
+mutable struct Style <: BaseStyle
     commands
 end
 mutable struct Interpreter
@@ -39,6 +39,8 @@ mutable struct Interpreter
     current_entry
     entries_var::Dict{String,Dict}
 end
+
+const Bibliography = Dict
 
 include("builtins.jl")
 function Interpreter(bib_format, bib_encoding)
@@ -163,7 +165,8 @@ abstract type AbstractParsedFunction end
 function ==(a::AbstractParsedFunction, b::AbstractParsedFunction)
 	return typeof(a) == typeof(B) && a.body == b.body
 end
-type ParsedFunction <: AbstractParsedFunction
+
+mutable struct ParsedFunction <: AbstractParsedFunction
 	body
 end
 
@@ -579,7 +582,6 @@ style        = BST.parse_file(joinpath(Pkg.dir("BibTeXFormat"),"test/format/apac
 formatted_entries = format_entries(style, bibliography)
 ```
 """
-
 function format_entries(b::Style, entries)
     run(Interpreter(b, "utf-8"), ["*"], transform_entries(entries))
 end

--- a/src/style/bst/bst.jl
+++ b/src/style/bst/bst.jl
@@ -40,7 +40,7 @@ mutable struct Interpreter
     entries_var::Dict{String,Dict}
 end
 
-const Bibliography = Dict
+const Bibliography = Dict{String, Dict}
 
 include("builtins.jl")
 function Interpreter(bib_format, bib_encoding)

--- a/src/style/bst/names.jl
+++ b/src/style/bst/names.jl
@@ -99,7 +99,7 @@ NON_LETTERS[1].match_options |=  Base.PCRE.ANCHORED |   Base.PCRE.CASELESS
 const FORMAT_CHARS = (r"[^\W\d_]+", "format chars")
 FORMAT_CHARS[1].match_options |=  Base.PCRE.ANCHORED |   Base.PCRE.CASELESS
 end
-doc"""
+"""
 ```
 struct NameFormat
 ```

--- a/src/style/labels.jl
+++ b/src/style/labels.jl
@@ -1,4 +1,4 @@
-import BibTeXFormat: citation_type, abbreviate
+#import BibTeXFormat: citation_type, abbreviate
 import Base.convert
 function  get_longest_label(formatted_entries)
     labels = [length(label) for (label,entry) in formatted_entries]
@@ -24,7 +24,6 @@ AABTesting123
 ```
 
 """
-
 function _strip_nonalnum(parts)
 	local s = Base.join(parts, "")
     return replace(_strip_accents(s),_nonalnum_pattern,"")

--- a/src/style/names.jl
+++ b/src/style/names.jl
@@ -19,7 +19,7 @@ end
 
 struct LastFirstNameStyle <: BaseNameStyle end
 #test in runtest.jl
-doc"""
+"""
 ```
 function format(self::LastFirstNameStyle, person, abbr=false)
 ```
@@ -67,7 +67,7 @@ end
 
 struct PlainNameStyle <: BaseNameStyle end
 #test in runtest.jl
-doc"""
+"""
 Format names similarly to {ff~}{vv~}{ll}{, jj} in BibTeX.
 
 ```julia

--- a/src/style/sorting.jl
+++ b/src/style/sorting.jl
@@ -6,7 +6,7 @@ function Base.sort(self::T, entries) where T <: BaseSortingStyle
 	return  [entry_dict[key] for key in sorted_keys]
 end
 import BibTeXFormat: citation_type
-type AuthorYearTitleSortingStyle <: BaseSortingStyle end
+mutable struct AuthorYearTitleSortingStyle <: BaseSortingStyle end
 
 function sorting_key(self::AuthorYearTitleSortingStyle, entry)
     local author_key = nothing

--- a/src/style/style.jl
+++ b/src/style/style.jl
@@ -26,11 +26,16 @@ struct Config
 end
 
 const Citation = Dict
-const Bibliography = Dict
+const Bibliography = Dict{String, Dict}
 
-function citation_type(t::Citation{T}) where {T}
-    return T
+#function citation_type(t::Citation{T}) where {T}
+#    return T
+#end
+
+function citation_type(e::Dict{String,String})
+    return e["type"]
 end
+
 function citation_type(e::Dict{String,Any})
     return e["type"]
 end
@@ -49,11 +54,12 @@ function transform(e::Citation, label)
     e_n["type"] = citation_type(e)
     e_n["key"] = label
     if haskey(e_n, "author")
-        e_n["persons"]["author"] = [Person(p) for p in split_name_list(e["author"])]
+        e_n["persons"]["author"] = [Person(String(p)) for p in split_name_list(e["author"])]
     end
-    pop!(e_n,"author")
+	pop!(e_n,"author")
     return e_n
 end
+
 function transform_entries(entries)
     local transformed_entries = Dict()
     for k in keys(entries)

--- a/src/style/style.jl
+++ b/src/style/style.jl
@@ -25,6 +25,9 @@ struct Config
 	end
 end
 
+const Citation = Dict
+const Bibliography = Dict
+
 function citation_type(t::Citation{T}) where {T}
     return T
 end
@@ -58,6 +61,7 @@ function transform_entries(entries)
     end
     return  transformed_entries
 end
+
 """
 ```
 function format_entries(b::T, entries::Dict) where T <: BaseStyle
@@ -70,7 +74,6 @@ bibliography      = Bibliography(readstring("test/Clustering.bib"))
 formatted_entries = format_entries(AlphaStyle,bibliography)
 ```
 """
-
 function format_entries(b::T, entries) where T <: BaseStyle
     entries = transform_entries(entries)
 	local sorted_entries = sort(b.config.sorting_style, entries)
@@ -202,7 +205,7 @@ function  get_crossreferenced_citations(entries, citations; min_crossrefs::Integ
 end
 
 """
-Expand wildcard citations (\citation{*} in .aux file).
+Expand wildcard citations (\\citation{*} in .aux file).
 ```jldoctest
 julia> using BibTeX
 
@@ -277,4 +280,3 @@ PlainAlphaStyle
 const PlainAlphaStyle = UNSRTStyle(Config())
 
 include("bst/bst.jl")
-

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -90,14 +90,14 @@ julia> split_tex_string("{Matsui      Fuuka}")
 1-element Array{String,1}:
  "{Matsui      Fuuka}"
 
-julia> split_tex_string(r"Matsui\ Fuuka")
+julia> split_tex_string(r"Matsui\\ Fuuka")
 2-element Array{String,1}:
  "Matsui"
  "Fuuka"
 
-julia> split_tex_string("{Matsui\ Fuuka}")
+julia> split_tex_string("{Matsui\\ Fuuka}")
 1-element Array{String,1}:
- "{Matsui\ Fuuka}"
+ "{Matsui\\ Fuuka}"
 
 julia> split_tex_string("a")
 1-element Array{String,1}:
@@ -365,7 +365,8 @@ function startswith(c::Char,b::Char)
 	return c==b
 end
 const purify_special_char_re = r"^\\[A-Za-z]+"
-doc"""
+
+"""
 ```julia
 function bibtex_purify(str)
 ```
@@ -429,7 +430,8 @@ function bibtex_purify(str)
 	end
     return Base.join(purify_iter(str),"")
 end
-doc"""
+
+"""
 ```julia
 function change_case(string, mode)
 ```
@@ -566,7 +568,7 @@ function bibtex_substring(string, start, len)
     return string[start0:end0]
 end
 
-doc"""
+"""
 Return the number of characters in the string.
 ```
 function bibtex_len(string)
@@ -614,7 +616,7 @@ function bibtex_len(string)
     return length
 end
 
-doc"""
+"""
 ```julia
 function  bibtex_first_letter(string)
 ```
@@ -629,7 +631,7 @@ A
 julia> print(bibtex_first_letter("1Andrew"))
 A
 julia> print(bibtex_first_letter("{\\TeX} markup"))
-{\TeX}
+{\\TeX}
 julia> print(bibtex_first_letter(""))
 
 julia> print(bibtex_first_letter("123 123 123 {}"))


### PR DESCRIPTION
I looked into updating the package for Julia 0.7 and at managed to get this to precompile. I don't think I can get any further with this, but decided to a pull request if this helps you further. 

I used this version of BibTex.jl https://github.com/mpastell/BIbTex.jl , which doesn't have `Citation` or `Bibliography`types defined. So I added these definitions to get rid of type errors.

```
const Citation = Dict
const Bibliography = Dict{String, Dict}
```

